### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
 prospector = ">=1.15.0"
+ruff = "0.15.7"
+pylint = "4.0.5"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.